### PR TITLE
Properly print digest value

### DIFF
--- a/src/main/java/software/amazon/qldb/tutorial/qldb/QldbStringUtils.java
+++ b/src/main/java/software/amazon/qldb/tutorial/qldb/QldbStringUtils.java
@@ -26,11 +26,15 @@ import com.amazonaws.services.qldb.model.GetDigestResult;
 import com.amazonaws.services.qldb.model.ValueHolder;
 
 import java.io.IOException;
+import java.util.Base64;
+import java.util.Base64.Encoder;
 
 /**
  * Helper methods to pretty-print certain QLDB response types.
  */
 public class QldbStringUtils {
+
+    private static final Encoder ENCODER = Base64.getEncoder();
 
     private QldbStringUtils() {}
 
@@ -93,7 +97,8 @@ public class QldbStringUtils {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
         if (getDigestResult.getDigest() != null) {
-            sb.append("Digest: ").append(getDigestResult.getDigest()).append(",");
+            String digest = ENCODER.encodeToString(getDigestResult.getDigest().array());
+            sb.append("Digest: ").append(digest).append(",");
         }
 
         if (getDigestResult.getDigestTipAddress() != null) {


### PR DESCRIPTION
A bug in `QldbStringUtils.java` is causing weird strings to be printed
 on certain tutorials. When running `GetRevision.java` and
 `GetDigest.java`, digests printed look like this:

```
2019-11-11 17:25:29.644 INFO --- [ main] s.a.q.t.GetDigest : Success. LedgerDigest: {Digest: java.nio.HeapByteBuffer[pos=0 lim=32 cap=32],DigestTipAddress: {IonText:
{
strandId:"KLXvz8qS9S2AqqOjDtWf0h",
sequenceNo:28
}}}.
```

Specifically, the `java.nio.HeapByteBuffer` is not intended; here, we
 expect to see the literal SHA256 hash value. This change properly
 encodes the string. After this change, the printed result looks like
 the following:

```
2019-11-12 16:17:32.192  INFO --- [main] s.a.q.t.GetDigest : Success. LedgerDigest: {Digest: W03
6oOZUJsa5wz5vMTuJr3S0gkB8tqB/kMj26J4VEj8=,DigestTipAddress: {IonText:
{
  strandId:"AohD4BF6f1DJdS3Pru8tqs",
  sequenceNo:4
}}}.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
