### PR TITLE
Add QLDB Streams sample

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,12 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-java-sdk-iam', version: '1.11.649'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.649'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.11.649'
+
+    runtime group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.9'
+    compile group: 'com.amazonaws', name: 'aws-java-sdk-qldb', version: '1.11.785'
+    compile group: 'com.amazonaws', name: 'amazon-kinesis-client', version: '1.11.2'
+
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-ion', version: '2.10.0.pr1'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.10.0.pr1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.11.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Apr 16 12:19:06 PDT 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/software/amazon/qldb/tutorial/Constants.java
+++ b/src/main/java/software/amazon/qldb/tutorial/Constants.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.dataformat.ion.ionvalue.IonValueMapper;
 public final class Constants {
     public static final int RETRY_LIMIT = 4;
     public static final String LEDGER_NAME = "vehicle-registration";
+    public static final String STREAM_NAME = "vehicle-registration-stream";
     public static final String VEHICLE_REGISTRATION_TABLE_NAME = "VehicleRegistration";
     public static final String VEHICLE_TABLE_NAME = "Vehicle";
     public static final String PERSON_TABLE_NAME = "Person";
@@ -42,8 +43,8 @@ public final class Constants {
     public static final String JOURNAL_EXPORT_S3_BUCKET_NAME_PREFIX = "qldb-tutorial-journal-export";
     public static final String USER_TABLES = "information_schema.user_tables";
     public static final String LEDGER_NAME_WITH_TAGS = "tags";
-    public static final IonObjectMapper MAPPER = new IonValueMapper(IonSystemBuilder.standard().build());
     public static final IonSystem SYSTEM = IonSystemBuilder.standard().build();
+    public static final IonObjectMapper MAPPER = new IonValueMapper(SYSTEM);
 
     private Constants() { }
 

--- a/src/main/java/software/amazon/qldb/tutorial/model/DriversLicense.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/DriversLicense.java
@@ -22,13 +22,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import software.amazon.qldb.tutorial.model.streams.RevisionData;
 
 import java.time.LocalDate;
 
 /**
  * Represents a driver's license, serializable to (and from) Ion.
  */
-public final class DriversLicense {
+public final class DriversLicense implements RevisionData {
     private final String personId;
     private final String licenseNumber;
     private final String licenseType;
@@ -77,5 +78,16 @@ public final class DriversLicense {
     @JsonProperty("ValidToDate")
     public LocalDate getValidToDate() {
         return  validToDate;
+    }
+
+    @Override
+    public String toString() {
+        return "DriversLicense{" +
+                "personId='" + personId + '\'' +
+                ", licenseNumber='" + licenseNumber + '\'' +
+                ", licenseType='" + licenseType + '\'' +
+                ", validFromDate=" + validFromDate +
+                ", validToDate=" + validToDate +
+                '}';
     }
 }

--- a/src/main/java/software/amazon/qldb/tutorial/model/IndexInfo.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/IndexInfo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Contains info about a given index.
+ */
+public class IndexInfo {
+    private String identifier;
+    private String expr;
+    private String status;
+
+    @JsonCreator
+    public IndexInfo(@JsonProperty("identifier") final String identifier,
+                     @JsonProperty("expr") final String expr,
+                     @JsonProperty("status") final String status) {
+        this.identifier = identifier;
+        this.expr = expr;
+        this.status = status;
+    }
+
+    /**
+     * An index's id. Upon creation, QLDB assigns a unique id to an index.
+     * @return The QLDB assigned index id.
+     */
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    /**
+     * The indexed document path. A string in the form, {@code "[<fieldName>]"}.
+     * @return The indexed document path representation.
+     */
+    public String getExpr() {
+        return expr;
+    }
+
+    /**
+     * The status of the index. One of {BUILDING, FINALIZING, ONLINE, FAILED}.
+     * The index is not used by QLDB in queries until the status is ONLINE.
+     * @return The index status.
+     */
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/software/amazon/qldb/tutorial/model/Owners.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/Owners.java
@@ -44,4 +44,12 @@ public final class Owners {
     public List<Owner> getSecondaryOwners() {
         return secondaryOwners;
     }
+
+    @Override
+    public String toString() {
+        return "Owners{" +
+                "primaryOwner=" + primaryOwner +
+                ", secondaryOwners=" + secondaryOwners +
+                '}';
+    }
 }

--- a/src/main/java/software/amazon/qldb/tutorial/model/Person.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/Person.java
@@ -24,13 +24,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import software.amazon.qldb.TransactionExecutor;
 import software.amazon.qldb.tutorial.Constants;
+import software.amazon.qldb.tutorial.model.streams.RevisionData;
+
+import java.time.LocalDate;
 
 import java.time.LocalDate;
 
 /**
  * Represents a person, serializable to (and from) Ion.
  */ 
-public final class Person {
+public final class Person implements RevisionData {
     private final String firstName;
     private final String lastName;
 
@@ -97,5 +100,17 @@ public final class Person {
      */
     public static String getDocumentIdByGovId(final TransactionExecutor txn, final String govId) {
         return SampleData.getDocumentId(txn, Constants.PERSON_TABLE_NAME, "GovId", govId);
+    }
+
+    @Override
+    public String toString() {
+        return "Person{" +
+                "firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", dob=" + dob +
+                ", govId='" + govId + '\'' +
+                ", govIdType='" + govIdType + '\'' +
+                ", address='" + address + '\'' +
+                '}';
     }
 }

--- a/src/main/java/software/amazon/qldb/tutorial/model/SampleData.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/SampleData.java
@@ -18,7 +18,6 @@
 
 package software.amazon.qldb.tutorial.model;
 
-import com.amazon.ion.Decimal;
 import com.amazon.ion.IonString;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonValue;
@@ -30,6 +29,8 @@ import software.amazon.qldb.tutorial.qldb.DmlResultDocument;
 import software.amazon.qldb.tutorial.qldb.QldbRevision;
 
 import java.io.IOException;
+
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -46,19 +47,19 @@ public final class SampleData {
 
     public static final List<VehicleRegistration> REGISTRATIONS = Collections.unmodifiableList(Arrays.asList(
             new VehicleRegistration("1N4AL11D75C109151", "LEWISR261LL", "WA", "Seattle",
-                    convertToDecimal(90.25), convertToLocalDate("2017-08-21"), convertToLocalDate("2020-05-11"),
+                    BigDecimal.valueOf(90.25), convertToLocalDate("2017-08-21"), convertToLocalDate("2020-05-11"),
                     new Owners(new Owner(null), Collections.emptyList())),
             new VehicleRegistration("KM8SRDHF6EU074761", "CA762X", "WA", "Kent",
-                    convertToDecimal(130.75), convertToLocalDate("2017-09-14"), convertToLocalDate("2020-06-25"),
+                    BigDecimal.valueOf(130.75), convertToLocalDate("2017-09-14"), convertToLocalDate("2020-06-25"),
                     new Owners(new Owner(null), Collections.emptyList())),
             new VehicleRegistration("3HGGK5G53FM761765", "CD820Z", "WA", "Everett",
-                    convertToDecimal(442.30), convertToLocalDate("2011-03-17"), convertToLocalDate("2021-03-24"),
+                    BigDecimal.valueOf(442.30), convertToLocalDate("2011-03-17"), convertToLocalDate("2021-03-24"),
                     new Owners(new Owner(null), Collections.emptyList())),
             new VehicleRegistration("1HVBBAANXWH544237", "LS477D", "WA", "Tacoma",
-                    convertToDecimal(42.20), convertToLocalDate("2011-10-26"), convertToLocalDate("2023-09-25"),
+                    BigDecimal.valueOf(42.20), convertToLocalDate("2011-10-26"), convertToLocalDate("2023-09-25"),
                     new Owners(new Owner(null), Collections.emptyList())),
             new VehicleRegistration("1C4RJFAG0FC625797", "TH393F", "WA", "Olympia",
-                    convertToDecimal(30.45), convertToLocalDate("2013-09-02"), convertToLocalDate("2024-03-19"),
+                    BigDecimal.valueOf(30.45), convertToLocalDate("2013-09-02"), convertToLocalDate("2024-03-19"),
                     new Owners(new Owner(null), Collections.emptyList()))
     ));
 
@@ -103,7 +104,7 @@ public final class SampleData {
      *
      * @param date
      *              The date string to convert.
-     * @return {@link java.time.LocalDate} or null if there is a {@link ParseException}
+     * @return {@link LocalDate} or null if there is a {@link ParseException}
      */
     public static synchronized LocalDate convertToLocalDate(String date) {
         return LocalDate.parse(date, DATE_TIME_FORMAT);
@@ -214,17 +215,6 @@ public final class SampleData {
      */
     public static String getStringValueOfStructField(final IonStruct struct, final String fieldName) {
         return ((IonString) struct.get(fieldName)).stringValue();
-    }
-
-    /**
-     * Convert the given double to a decimal value.
-     *
-     * @param num
-     *              The double to convert.
-     * @return the decimal value of the double.
-     */
-    private static synchronized Decimal convertToDecimal(final double num) {
-        return Decimal.valueOf(num);
     }
 
     /**

--- a/src/main/java/software/amazon/qldb/tutorial/model/Vehicle.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/Vehicle.java
@@ -20,11 +20,12 @@ package software.amazon.qldb.tutorial.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import software.amazon.qldb.tutorial.model.streams.RevisionData;
 
 /**
  * Represents a vehicle, serializable to (and from) Ion.
  */
-public final class Vehicle {
+public final class Vehicle implements RevisionData {
     private final String vin;
     private final String type;
     private final int year;
@@ -75,5 +76,17 @@ public final class Vehicle {
     @JsonProperty("Year")
     public int getYear() {
         return year;
+    }
+
+    @Override
+    public String toString() {
+        return "Vehicle{" +
+                "vin='" + vin + '\'' +
+                ", type='" + type + '\'' +
+                ", year=" + year +
+                ", make='" + make + '\'' +
+                ", model='" + model + '\'' +
+                ", color='" + color + '\'' +
+                '}';
     }
 }

--- a/src/main/java/software/amazon/qldb/tutorial/model/VehicleRegistration.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/VehicleRegistration.java
@@ -18,25 +18,27 @@
 
 package software.amazon.qldb.tutorial.model;
 
-import com.amazon.ion.Decimal;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import software.amazon.qldb.TransactionExecutor;
 import software.amazon.qldb.tutorial.Constants;
+import software.amazon.qldb.tutorial.model.streams.RevisionData;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 /**
  * Represents a vehicle registration, serializable to (and from) Ion.
  */ 
-public final class VehicleRegistration {
+public final class VehicleRegistration implements RevisionData {
+
     private final String vin;
     private final String licensePlateNumber;
     private final String state;
     private final String city;
-    private final Decimal pendingPenaltyTicketAmount;
+    private final BigDecimal pendingPenaltyTicketAmount;
     private final LocalDate validFromDate;
     private final LocalDate validToDate;
     private final Owners owners;
@@ -46,7 +48,7 @@ public final class VehicleRegistration {
                                @JsonProperty("LicensePlateNumber") final String licensePlateNumber,
                                @JsonProperty("State") final String state,
                                @JsonProperty("City") final String city,
-                               @JsonProperty("PendingPenaltyTicketAmount") final Decimal pendingPenaltyTicketAmount,
+                               @JsonProperty("PendingPenaltyTicketAmount") final BigDecimal pendingPenaltyTicketAmount,
                                @JsonProperty("ValidFromDate") final LocalDate validFromDate,
                                @JsonProperty("ValidToDate") final LocalDate validToDate,
                                @JsonProperty("Owners") final Owners owners) {
@@ -76,7 +78,7 @@ public final class VehicleRegistration {
     }
 
     @JsonProperty("PendingPenaltyTicketAmount")
-    public Decimal getPendingPenaltyTicketAmount() {
+    public BigDecimal getPendingPenaltyTicketAmount() {
         return pendingPenaltyTicketAmount;
     }
 
@@ -115,5 +117,19 @@ public final class VehicleRegistration {
      */
     public static String getDocumentIdByVin(final TransactionExecutor txn, final String vin) {
         return SampleData.getDocumentId(txn, Constants.VEHICLE_REGISTRATION_TABLE_NAME, "VIN", vin);
+    }
+
+    @Override
+    public String toString() {
+        return "VehicleRegistration{" +
+                "vin='" + vin + '\'' +
+                ", licensePlateNumber='" + licensePlateNumber + '\'' +
+                ", state='" + state + '\'' +
+                ", city='" + city + '\'' +
+                ", pendingPenaltyTicketAmount=" + pendingPenaltyTicketAmount +
+                ", validFromDate=" + validFromDate +
+                ", validToDate=" + validToDate +
+                ", owners=" + owners +
+                '}';
     }
 }

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/BlockSummaryRecord.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/BlockSummaryRecord.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.model.streams;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.ion.IonTimestampSerializers;
+import software.amazon.qldb.tutorial.qldb.BlockAddress;
+import software.amazon.qldb.tutorial.qldb.TransactionInfo;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a summary for a Journal Block that was recorded after executing a
+ * transaction in the ledger.
+ */
+public final class BlockSummaryRecord implements StreamRecord.StreamRecordPayload {
+    private BlockAddress blockAddress;
+    private String transactionId;
+    @JsonSerialize(using = IonTimestampSerializers.IonTimestampJavaDateSerializer.class)
+    private Date blockTimestamp;
+    private byte[] blockHash;
+    private byte[] entriesHash;
+    private byte[] previousBlockHash;
+    private byte[][] entriesHashList;
+    private TransactionInfo transactionInfo;
+    private List<RevisionSummary> revisionSummaries;
+
+    @JsonCreator
+    public BlockSummaryRecord(@JsonProperty("blockAddress") final BlockAddress blockAddress,
+                              @JsonProperty("transactionId") final String transactionId,
+                              @JsonProperty("blockTimestamp") final Date blockTimestamp,
+                              @JsonProperty("blockHash") final byte[] blockHash,
+                              @JsonProperty("entriesHash") final byte[] entriesHash,
+                              @JsonProperty("previousBlockHash") final byte[] previousBlockHash,
+                              @JsonProperty("entriesHashList") final byte[][] entriesHashList,
+                              @JsonProperty("transactionInfo") final TransactionInfo transactionInfo,
+                              @JsonProperty("revisionSummaries") final List<RevisionSummary> revisionSummaries) {
+        this.blockAddress = blockAddress;
+        this.transactionId = transactionId;
+        this.blockTimestamp = blockTimestamp;
+        this.blockHash = blockHash;
+        this.entriesHash = entriesHash;
+        this.previousBlockHash = previousBlockHash;
+        this.entriesHashList = entriesHashList;
+        this.transactionInfo = transactionInfo;
+        this.revisionSummaries = revisionSummaries;
+    }
+
+    @Override
+    public String toString() {
+        return "JournalBlock{"
+                + "blockAddress=" + blockAddress
+                + ", transactionId='" + transactionId + '\''
+                + ", blockTimestamp=" + blockTimestamp
+                + ", blockHash=" + Arrays.toString(blockHash)
+                + ", entriesHash=" + Arrays.toString(entriesHash)
+                + ", previousBlockHash=" + Arrays.toString(previousBlockHash)
+                + ", entriesHashList=" + Arrays.stream(entriesHashList).map(Arrays::toString).collect(Collectors.toList())
+                + ", transactionInfo=" + transactionInfo
+                + ", revisionSummaries=" + revisionSummaries
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BlockSummaryRecord that = (BlockSummaryRecord) o;
+
+        if (!Objects.equals(blockAddress, that.blockAddress)) {
+            return false;
+        }
+        if (!Objects.equals(transactionId, that.transactionId)) {
+            return false;
+        }
+        if (!Objects.equals(blockTimestamp, that.blockTimestamp)) {
+            return false;
+        }
+        if (!Arrays.equals(blockHash, that.blockHash)) {
+            return false;
+        }
+        if (!Arrays.equals(entriesHash, that.entriesHash)) {
+            return false;
+        }
+        if (!Arrays.equals(previousBlockHash, that.previousBlockHash)) {
+            return false;
+        }
+        if (!Arrays.deepEquals(entriesHashList, that.entriesHashList)) {
+            return false;
+        }
+        if (!Objects.equals(transactionInfo, that.transactionInfo)) {
+            return false;
+        }
+        return Objects.equals(revisionSummaries, that.revisionSummaries);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = blockAddress != null ? blockAddress.hashCode() : 0;
+        result = 31 * result + (transactionId != null ? transactionId.hashCode() : 0);
+        result = 31 * result + (blockTimestamp != null ? blockTimestamp.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(blockHash);
+        result = 31 * result + Arrays.hashCode(entriesHash);
+        result = 31 * result + Arrays.hashCode(previousBlockHash);
+        result = 31 * result + Arrays.deepHashCode(entriesHashList);
+        result = 31 * result + (transactionInfo != null ? transactionInfo.hashCode() : 0);
+        result = 31 * result + (revisionSummaries != null ? revisionSummaries.hashCode() : 0);
+        return result;
+    }
+
+    public BlockAddress getBlockAddress() {
+        return blockAddress;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public Date getBlockTimestamp() {
+        return blockTimestamp;
+    }
+
+    public byte[] getBlockHash() {
+        return blockHash;
+    }
+
+    public byte[] getEntriesHash() {
+        return entriesHash;
+    }
+
+    public byte[] getPreviousBlockHash() {
+        return previousBlockHash;
+    }
+
+    public byte[][] getEntriesHashList() {
+        return entriesHashList;
+    }
+
+    public TransactionInfo getTransactionInfo() {
+        return transactionInfo;
+    }
+
+    public List<RevisionSummary> getRevisionSummaries() {
+        return revisionSummaries;
+    }
+
+}

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/ControlRecord.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/ControlRecord.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.model.streams;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Represents a control record on the QLDB stream. QLDB stream writes control
+ * records to indicate its start and completion events.
+ */
+@JsonDeserialize(using = ControlRecord.Deserializer.class)
+public final class ControlRecord implements StreamRecord.StreamRecordPayload {
+
+    private String recordType;
+
+    public ControlRecord(String recordType) {
+        this.recordType = recordType;
+    }
+
+    @Override
+    public String toString() {
+        return "ControlRecord{" +
+                "recordType='" + recordType + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ControlRecord that = (ControlRecord) o;
+
+        return Objects.equals(recordType, that.recordType);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = recordType != null ? recordType.hashCode() : 0;
+        return result * 31;
+    }
+
+    public String getRecordType() {
+        return recordType;
+    }
+
+    public static class Deserializer extends StdDeserializer<ControlRecord> {
+        public Deserializer() {
+            this(null);
+        }
+
+        private Deserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public ControlRecord deserialize(JsonParser jsonParser, DeserializationContext ctx) throws IOException {
+            ObjectCodec codec = jsonParser.getCodec();
+            JsonNode node = codec.readTree(jsonParser);
+            String controlRecordType = node.get("controlRecordType").textValue();
+
+            return new ControlRecord(controlRecordType);
+        }
+    }
+}

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/Revision.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/Revision.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.model.streams;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import software.amazon.qldb.tutorial.model.DriversLicense;
+import software.amazon.qldb.tutorial.model.Person;
+import software.amazon.qldb.tutorial.model.Vehicle;
+import software.amazon.qldb.tutorial.model.VehicleRegistration;
+import software.amazon.qldb.tutorial.qldb.BlockAddress;
+import software.amazon.qldb.tutorial.qldb.RevisionMetadata;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Represents a Revision including both user data and metadata.
+ */
+public final class Revision {
+    private final BlockAddress blockAddress;
+    private final RevisionMetadata metadata;
+    private final byte[] hash;
+    @JsonDeserialize(using = RevisionDataDeserializer.class)
+    private final RevisionData data;
+
+    @JsonCreator
+    public Revision(@JsonProperty("blockAddress") final BlockAddress blockAddress,
+                    @JsonProperty("metadata") final RevisionMetadata metadata,
+                    @JsonProperty("hash") final byte[] hash,
+                    @JsonProperty("data") final RevisionData data) {
+        this.blockAddress = blockAddress;
+        this.metadata = metadata;
+        this.hash = hash;
+        this.data = data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Revision revision = (Revision) o;
+
+        if (!Objects.equals(blockAddress, revision.blockAddress)) {
+            return false;
+        }
+        if (!Objects.equals(metadata, revision.metadata)) {
+            return false;
+        }
+        if (!Arrays.equals(hash, revision.hash)) {
+            return false;
+        }
+        return Objects.equals(data, revision.data);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = blockAddress != null ? blockAddress.hashCode() : 0;
+        result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(hash);
+        result = 31 * result + (data != null ? data.hashCode() : 0);
+        return result;
+    }
+
+    /**
+     * Converts a {@link Revision} object to string.
+     *
+     * @return the string representation of the {@link Revision} object.
+     */
+    @Override
+    public String toString() {
+        return "Revision{" +
+                "blockAddress=" + blockAddress +
+                ", metadata=" + metadata +
+                ", hash=" + Arrays.toString(hash) +
+                ", data=" + data +
+                '}';
+    }
+
+    public BlockAddress getBlockAddress() {
+        return blockAddress;
+    }
+
+    public RevisionMetadata getMetadata() {
+        return metadata;
+    }
+
+    public byte[] getHash() {
+        return hash;
+    }
+
+    public RevisionData getData() {
+        return data;
+    }
+
+    public static class RevisionDataDeserializer extends JsonDeserializer<RevisionData> {
+
+        @Override
+        public RevisionData deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
+            TableInfo tableInfo = (TableInfo) jp.getParsingContext().getParent().getCurrentValue();
+            RevisionData revisionData;
+            switch (tableInfo.getTableName()) {
+                case "VehicleRegistration":
+                    revisionData = jp.readValueAs(VehicleRegistration.class);
+                    break;
+                case "Person":
+                    revisionData = jp.readValueAs(Person.class);
+                    break;
+                case "DriversLicense":
+                    revisionData = jp.readValueAs(DriversLicense.class);
+                    break;
+                case "Vehicle":
+                    revisionData = jp.readValueAs(Vehicle.class);
+                    break;
+                default:
+                    throw new RuntimeException("Unsupported table " + tableInfo.getTableName());
+            }
+
+            return revisionData;
+        }
+    }
+}

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/RevisionData.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/RevisionData.java
@@ -16,29 +16,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package software.amazon.qldb.tutorial.model;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
+package software.amazon.qldb.tutorial.model.streams;
 
 /**
- * Represents a vehicle owner, serializable to (and from) Ion.
- */ 
-public final class Owner {
-    private final String personId;
-
-    public Owner(@JsonProperty("PersonId") final String personId) {
-        this.personId = personId;
-    }
-
-    @JsonProperty("PersonId")
-    public String getPersonId() {
-        return personId;
-    }
-
-    @Override
-    public String toString() {
-        return "Owner{" +
-                "personId='" + personId + '\'' +
-                '}';
-    }
-}
+ * Allows modeling the content of all revisions as a generic revision data. Used
+ * in the {@link Revision} and extended by domain models in {@link
+ * software.amazon.qldb.tutorial.model} to make it easier to write the {@link
+ * Revision.RevisionDataDeserializer} that must deserialize the {@link
+ * Revision#data} from different domain models.
+ */
+public interface RevisionData { }

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/RevisionDetailsRecord.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/RevisionDetailsRecord.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.model.streams;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Represents a revision record on the QLDB stream. A revision details record
+ * represents a document revision that is committed to your ledger. The payload
+ * contains all of the attributes from the committed view of the revision, along
+ * with the associated table name and table ID.
+ */
+public final class RevisionDetailsRecord implements StreamRecord.StreamRecordPayload {
+    private TableInfo tableInfo;
+    private Revision revision;
+
+    public RevisionDetailsRecord(@JsonProperty("tableInfo") TableInfo tableInfo, @JsonProperty("revision") Revision revision) {
+        this.tableInfo = tableInfo;
+        this.revision = revision;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RevisionDetailsRecord that = (RevisionDetailsRecord) o;
+
+        if (!Objects.equals(tableInfo, that.tableInfo)) {
+            return false;
+        }
+        return Objects.equals(revision, that.revision);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tableInfo != null ? tableInfo.hashCode() : 0;
+        result = 31 * result + (revision != null ? revision.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RevisionDetailsRecord{" +
+                "tableInfo=" + tableInfo +
+                ", revision=" + revision +
+                '}';
+    }
+
+    public TableInfo getTableInfo() {
+        return tableInfo;
+    }
+
+    public Revision getRevision() {
+        return revision;
+    }
+}

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/RevisionSummary.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/RevisionSummary.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.model.streams;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Represents the revision summary that appears in the {@link
+ * BlockSummaryRecord}. Some revisions might not have a documentId. These are
+ * internal-only system revisions that don't contain user data. Only the
+ * revisions that do have a document ID are published in separate revision
+ * details record.
+ */
+public final class RevisionSummary {
+
+    private String documentId;
+    private byte[] hash;
+
+    @JsonCreator
+    public RevisionSummary(@JsonProperty("documentId") String documentId, @JsonProperty("hash") byte[] hash) {
+        this.documentId = documentId;
+        this.hash = hash;
+    }
+
+    @Override
+    public String toString() {
+        return "RevisionSummary{" +
+                "documentId='" + documentId + '\'' +
+                ", hash=" + Arrays.toString(hash) +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RevisionSummary that = (RevisionSummary) o;
+
+        if (!Objects.equals(documentId, that.documentId)) {
+            return false;
+        }
+        return Arrays.equals(hash, that.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = documentId != null ? documentId.hashCode() : 0;
+        result = 31 * result + Arrays.hashCode(hash);
+        return result;
+    }
+
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public byte[] getHash() {
+        return hash;
+    }
+}

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/StreamRecord.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/StreamRecord.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.model.streams;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Represents a record on the Qldb stream. An Amazon QLDB stream writes three
+ * types of data records to a given Amazon Kinesis Data Streams resource:
+ * control, block summary, and revision details.
+ * <p>
+ * Control records indicate the start and completion of your QLDB streams.
+ * Whenever a revision is committed to your ledger, a QLDB stream writes all of
+ * the associated journal block data in block summary and revision details
+ * records.
+ *
+ * @see ControlRecord
+ * @see BlockSummaryRecord
+ * @see RevisionDetailsRecord
+ */
+@JsonDeserialize(using = StreamRecord.Deserializer.class)
+public class StreamRecord {
+    private String qldbStreamArn;
+    private String recordType;
+    private StreamRecordPayload payload;
+
+    public StreamRecord(String qldbStreamArn, String recordType, StreamRecordPayload payload) {
+        this.qldbStreamArn = qldbStreamArn;
+        this.recordType = recordType;
+        this.payload = payload;
+    }
+
+    @Override
+    public String toString() {
+        return "StreamRecord{" +
+                "qldbStreamArn='" + qldbStreamArn + '\'' +
+                ", recordType='" + recordType + '\'' +
+                ", payload=" + payload +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        StreamRecord that = (StreamRecord) o;
+
+        if (!Objects.equals(qldbStreamArn, that.qldbStreamArn)) {
+            return false;
+        }
+        if (!Objects.equals(recordType, that.recordType)) {
+            return false;
+        }
+        return Objects.equals(payload, that.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = qldbStreamArn != null ? qldbStreamArn.hashCode() : 0;
+        result = 31 * result + (recordType != null ? recordType.hashCode() : 0);
+        result = 31 * result + (payload != null ? payload.hashCode() : 0);
+        return result;
+    }
+
+    public String getRecordType() {
+        return recordType;
+    }
+
+    public StreamRecordPayload getPayload() {
+        return payload;
+    }
+
+    public String getQldbStreamArn() {
+        return qldbStreamArn;
+    }
+
+    public interface StreamRecordPayload { }
+
+    static class Deserializer extends StdDeserializer<StreamRecord> {
+        private Deserializer() {
+            this(null);
+        }
+
+        private Deserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public StreamRecord deserialize(JsonParser jp, DeserializationContext dc)
+                throws IOException {
+            ObjectCodec codec = jp.getCodec();
+            JsonNode node = codec.readTree(jp);
+            String qldbStreamArn = node.get("qldbStreamArn").textValue();
+            String recordType = node.get("recordType").textValue();
+            JsonNode payloadJson = node.get("payload");
+            StreamRecordPayload payload = null;
+
+            switch (recordType) {
+                case "CONTROL":
+                    payload = codec.treeToValue(payloadJson, ControlRecord.class);
+                    break;
+                case "BLOCK_SUMMARY":
+                    payload = codec.treeToValue(payloadJson, BlockSummaryRecord.class);
+                    break;
+                case "REVISION_DETAILS":
+                    payload = codec.treeToValue(payloadJson, RevisionDetailsRecord.class);
+                    break;
+                default:
+                    throw new RuntimeException("Unsupported record type: " + recordType);
+            }
+
+            return new StreamRecord(qldbStreamArn, recordType, payload);
+        }
+
+    }
+}

--- a/src/main/java/software/amazon/qldb/tutorial/model/streams/TableInfo.java
+++ b/src/main/java/software/amazon/qldb/tutorial/model/streams/TableInfo.java
@@ -16,30 +16,26 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package software.amazon.qldb.tutorial.qldb;
+package software.amazon.qldb.tutorial.model.streams;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.List;
+import java.util.Objects;
 
 /**
- * Information about an individual document in a table and the transactions associated with that document
- * in the given JournalBlock.
+ * Represents the table information that goes inside the {@link
+ * RevisionDetailsRecord}. It allows the users to deserialize the {@link
+ * Revision#data} appropriate to the underlying table.
  */
-public class DocumentInfo {
-
-    private String tableName;
+public final class TableInfo {
     private String tableId;
-    private List<Integer> statementIndexList;
+    private String tableName;
 
     @JsonCreator
-    public DocumentInfo(@JsonProperty("tableName") final String tableName,
-                        @JsonProperty("tableId") final String tableId,
-                        @JsonProperty("statements") final List<Integer> statementIndexList) {
-        this.tableName = tableName;
+    public TableInfo(@JsonProperty("tableId") String tableId, @JsonProperty("tableName") String tableName) {
         this.tableId = tableId;
-        this.statementIndexList = statementIndexList;
+        this.tableName = tableName;
     }
 
     public String getTableName() {
@@ -50,44 +46,35 @@ public class DocumentInfo {
         return tableId;
     }
 
-    @JsonProperty("statements")
-    public List<Integer> getStatementIndexList() {
-        return statementIndexList;
+    @Override
+    public String toString() {
+        return "TableInfo{" +
+                "tableId='" + tableId + '\'' +
+                ", tableName='" + tableName + '\'' +
+                '}';
     }
 
     @Override
-    public boolean equals(final Object o) {
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof DocumentInfo)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
-        final DocumentInfo that = (DocumentInfo) o;
+        TableInfo tableInfo = (TableInfo) o;
 
-        if (!getTableName().equals(that.getTableName())) {
+        if (!Objects.equals(tableId, tableInfo.tableId)) {
             return false;
         }
-        if (!getTableId().equals(that.getTableId())) {
-            return false;
-        }
-        return getStatementIndexList().equals(that.getStatementIndexList());
+        return Objects.equals(tableName, tableInfo.tableName);
     }
 
     @Override
     public int hashCode() {
-        int result = getTableName().hashCode();
-        result = 31 * result + getTableId().hashCode();
-        result = 31 * result + getStatementIndexList().hashCode();
+        int result = tableId != null ? tableId.hashCode() : 0;
+        result = 31 * result + (tableName != null ? tableName.hashCode() : 0);
         return result;
-    }
-
-    @Override
-    public String toString() {
-        return "DocumentInfo{"
-            + "tableName='" + tableName + '\''
-            + ", tableId='" + tableId + '\''
-            + ", statementIndexList=" + statementIndexList + '}';
     }
 }

--- a/src/main/java/software/amazon/qldb/tutorial/qldb/QldbIonUtils.java
+++ b/src/main/java/software/amazon/qldb/tutorial/qldb/QldbIonUtils.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.qldb;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonValue;
+import com.amazon.ionhash.IonHashReader;
+import com.amazon.ionhash.IonHashReaderBuilder;
+import com.amazon.ionhash.MessageDigestIonHasherProvider;
+import software.amazon.qldb.tutorial.Constants;
+
+public class QldbIonUtils {
+
+    private static MessageDigestIonHasherProvider ionHasherProvider = new MessageDigestIonHasherProvider("SHA-256");
+
+    private QldbIonUtils() {}
+
+    /**
+     * Builds a hash value from the given {@link IonValue}.
+     *
+     * @param ionValue
+     *              The {@link IonValue} to hash.
+     * @return a byte array representing the hash value.
+     */
+    public static byte[] hashIonValue(final IonValue ionValue) {
+        IonReader reader = Constants.SYSTEM.newReader(ionValue);
+        IonHashReader hashReader = IonHashReaderBuilder.standard()
+                .withHasherProvider(ionHasherProvider)
+                .withReader(reader)
+                .build();
+        while (hashReader.next() != null) {  }
+        return hashReader.digest();
+    }
+
+}

--- a/src/main/java/software/amazon/qldb/tutorial/qldb/QldbStringUtils.java
+++ b/src/main/java/software/amazon/qldb/tutorial/qldb/QldbStringUtils.java
@@ -26,15 +26,11 @@ import com.amazonaws.services.qldb.model.GetDigestResult;
 import com.amazonaws.services.qldb.model.ValueHolder;
 
 import java.io.IOException;
-import java.util.Base64;
-import java.util.Base64.Encoder;
 
 /**
  * Helper methods to pretty-print certain QLDB response types.
  */
 public class QldbStringUtils {
-
-    private static final Encoder ENCODER = Base64.getEncoder();
 
     private QldbStringUtils() {}
 
@@ -97,8 +93,7 @@ public class QldbStringUtils {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
         if (getDigestResult.getDigest() != null) {
-            String digest = ENCODER.encodeToString(getDigestResult.getDigest().array());
-            sb.append("Digest: ").append(digest).append(",");
+            sb.append("Digest: ").append(getDigestResult.getDigest()).append(",");
         }
 
         if (getDigestResult.getDigestTipAddress() != null) {

--- a/src/main/java/software/amazon/qldb/tutorial/qldb/RevisionMetadata.java
+++ b/src/main/java/software/amazon/qldb/tutorial/qldb/RevisionMetadata.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.qldb;
+
+import com.amazon.ion.IonInt;
+import com.amazon.ion.IonString;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonTimestamp;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.dataformat.ion.IonTimestampSerializers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * Represents the metadata field of a QLDB Document
+ */
+public class RevisionMetadata {
+    private static final Logger log = LoggerFactory.getLogger(RevisionMetadata.class);
+    private final String id;
+    private final long version;
+    @JsonSerialize(using = IonTimestampSerializers.IonTimestampJavaDateSerializer.class)
+    private final Date txTime;
+    private final String txId;
+
+    @JsonCreator
+    public RevisionMetadata(@JsonProperty("id") final String id,
+                            @JsonProperty("version") final long version,
+                            @JsonProperty("txTime") final Date txTime,
+                            @JsonProperty("txId") final String txId) {
+        this.id = id;
+        this.version = version;
+        this.txTime = txTime;
+        this.txId = txId;
+    }
+
+    /**
+     * Gets the unique ID of a QLDB document.
+     *
+     * @return the document ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Gets the version number of the document in the document's modification history.
+     * @return the version number.
+     */
+    public long getVersion() {
+        return version;
+    }
+
+    /**
+     * Gets the time during which the document was modified.
+     *
+     * @return the transaction time.
+     */
+    public Date getTxTime() {
+        return txTime;
+    }
+
+    /**
+     * Gets the transaction ID associated with this document.
+     *
+     * @return the transaction ID.
+     */
+    public String getTxId() {
+        return txId;
+    }
+
+    public static RevisionMetadata fromIon(final IonStruct ionStruct) {
+        if (ionStruct == null) {
+            throw new IllegalArgumentException("Metadata cannot be null");
+        }
+        try {
+            IonString id = (IonString) ionStruct.get("id");
+            IonInt version = (IonInt) ionStruct.get("version");
+            IonTimestamp txTime = (IonTimestamp) ionStruct.get("txTime");
+            IonString txId = (IonString) ionStruct.get("txId");
+            if (id == null || version == null || txTime == null || txId == null) {
+                throw new IllegalArgumentException("Document is missing required fields");
+            }
+            return new RevisionMetadata(id.stringValue(), version.longValue(), new Date(txTime.getMillis()), txId.stringValue());
+        } catch (ClassCastException e) {
+            log.error("Failed to parse ion document");
+            throw new IllegalArgumentException("Document members are not of the correct type", e);
+        }
+    }
+
+    /**
+     * Converts a {@link RevisionMetadata} object to a string.
+     *
+     * @return the string representation of the {@link QldbRevision} object.
+     */
+    @Override
+    public String toString() {
+        return "Metadata{"
+                + "id='" + id + '\''
+                + ", version=" + version
+                + ", txTime=" + txTime
+                + ", txId='" + txId
+                + '\''
+                + '}';
+    }
+
+    /**
+     * Check whether two {@link RevisionMetadata} objects are equivalent.
+     *
+     * @return {@code true} if the two objects are equal, {@code false} otherwise.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        RevisionMetadata metadata = (RevisionMetadata) o;
+        return version == metadata.version
+                && id.equals(metadata.id)
+                && txTime.equals(metadata.txTime)
+                && txId.equals(metadata.txId);
+    }
+
+    /**
+     * Generate a hash code for the {@link RevisionMetadata} object.
+     *
+     * @return the hash code.
+     */
+    @Override
+    public int hashCode() {
+        // CHECKSTYLE:OFF - Disabling as we are generating a hashCode of multiple properties.
+        return Objects.hash(id, version, txTime, txId);
+        // CHECKSTYLE:ON
+    }
+}

--- a/src/main/java/software/amazon/qldb/tutorial/qldb/TransactionInfo.java
+++ b/src/main/java/software/amazon/qldb/tutorial/qldb/TransactionInfo.java
@@ -19,6 +19,7 @@
 package software.amazon.qldb.tutorial.qldb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.Map;
  * part of the transaction and mapping between the documents to
  * tableName/tableId which were updated as part of the transaction.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionInfo {
 
     private List<StatementInfo> statements;

--- a/src/main/java/software/amazon/qldb/tutorial/streams/README.md
+++ b/src/main/java/software/amazon/qldb/tutorial/streams/README.md
@@ -1,0 +1,54 @@
+# Amazon QLDB Java DMV Sample for Streams
+
+
+The StreamJournal sample provides guidance on how to use Amazon QLDB Streams.
+
+## Requirements
+
+### Basic Configuration
+
+See [Accessing Amazon QLDB](https://docs.aws.amazon.com/qldb/latest/developerguide/accessing.html) for information on connecting to AWS.
+
+### Java 8 and Gradle
+
+The StreamJournal sample is written in Java 8 using the Gradle build tool. Java 8 must be installed to build the examples, however 
+the Gradle wrapper is bundled in the project and does not need to be installed. Please see the link below for more 
+detail to install Java 8 and information on Gradle:
+
+* [Java 8 Installation](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html)
+* [Gradle](https://gradle.org/)
+* [Gradle Wrapper](https://docs.gradle.org/3.3/userguide/gradle_wrapper.html)
+
+## Running the Sample code
+
+The StreamJournal class contains a code example that demonstrates the following operations:
+
+* Create a ledger named vehicle-registration - `createLedger()`
+
+> **_Note:_** Before running this program, make sure that you don't already have an active ledger named vehicle-registration.
+
+* Create tables named Person, Vehicle, DriversLicense and VehicleRegistration - `createTables()`
+
+* Load sample data into the tables - `insertDocuments()`
+
+* Create an [AWS Kinesis](https://aws.amazon.com/kinesis/) data stream, an IAM role that enables QLDB to assume write permissions for the Kinesis data stream, and a QLDB journal stream - `createQldbStream()`
+
+* Use the [Kinesis Client Library](https://docs.aws.amazon.com/streams/latest/dev/shared-throughput-kcl-consumers.html#shared-throughput-kcl-consumers-overview) to start a stream reader that processes the Kinesis data stream and logs each QLDB data record - `startStreamReader()`
+
+* Use the stream data to validate the hash chain of the vehicle-registration ledger - `validateStreamRecordsHashChain()`
+
+* Clean up all resources by stopping the stream reader, cancelling the QLDB stream, deleting the ledger, and deleting the Kinesis data stream  - `cleanupQldbResources(), cleanupKinesisResources()`
+
+To run the StreamJournal program, enter the following command from your project root directory.
+
+Windows:
+
+```
+gradlew run -Dtutorial=streams.StreamJournal
+```
+
+Unix:
+
+```
+./gradlew run -Dtutorial=streams.StreamJournal
+```

--- a/src/main/java/software/amazon/qldb/tutorial/streams/StreamJournal.java
+++ b/src/main/java/software/amazon/qldb/tutorial/streams/StreamJournal.java
@@ -1,0 +1,720 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package software.amazon.qldb.tutorial.streams;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.system.IonReaderBuilder;
+import com.amazon.ion.system.IonTextWriterBuilder;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder;
+import com.amazonaws.services.identitymanagement.model.CreateRoleRequest;
+import com.amazonaws.services.identitymanagement.model.GetRolePolicyRequest;
+import com.amazonaws.services.identitymanagement.model.GetRoleRequest;
+import com.amazonaws.services.identitymanagement.model.NoSuchEntityException;
+import com.amazonaws.services.identitymanagement.model.PutRolePolicyRequest;
+import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessor;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer;
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorFactory;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.KinesisClientLibConfiguration;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.ShutdownReason;
+import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker;
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamResult;
+import com.amazonaws.services.kinesis.model.Record;
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+import com.amazonaws.services.qldb.AmazonQLDB;
+import com.amazonaws.services.qldb.AmazonQLDBClientBuilder;
+import com.amazonaws.services.qldb.model.CancelJournalKinesisStreamRequest;
+import com.amazonaws.services.qldb.model.DescribeJournalKinesisStreamRequest;
+import com.amazonaws.services.qldb.model.DescribeJournalKinesisStreamResult;
+import com.amazonaws.services.qldb.model.JournalKinesisStreamDescription;
+import com.amazonaws.services.qldb.model.KinesisConfiguration;
+import com.amazonaws.services.qldb.model.ListJournalKinesisStreamsForLedgerRequest;
+import com.amazonaws.services.qldb.model.ListJournalKinesisStreamsForLedgerResult;
+import com.amazonaws.services.qldb.model.StreamJournalToKinesisRequest;
+import com.amazonaws.services.qldb.model.StreamJournalToKinesisResult;
+import com.fasterxml.jackson.databind.ObjectReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.qldb.tutorial.Constants;
+import software.amazon.qldb.tutorial.CreateLedger;
+import software.amazon.qldb.tutorial.CreateTable;
+import software.amazon.qldb.tutorial.DeleteLedger;
+import software.amazon.qldb.tutorial.DeletionProtection;
+import software.amazon.qldb.tutorial.InsertDocument;
+import software.amazon.qldb.tutorial.ValidateQldbHashChain;
+import software.amazon.qldb.tutorial.model.SampleData;
+import software.amazon.qldb.tutorial.model.streams.BlockSummaryRecord;
+import software.amazon.qldb.tutorial.model.streams.Revision;
+import software.amazon.qldb.tutorial.model.streams.RevisionDetailsRecord;
+import software.amazon.qldb.tutorial.model.streams.StreamRecord;
+import software.amazon.qldb.tutorial.qldb.JournalBlock;
+import software.amazon.qldb.tutorial.qldb.QldbRevision;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream.TRIM_HORIZON;
+import static java.lang.Thread.sleep;
+import static java.nio.ByteBuffer.wrap;
+import static software.amazon.qldb.tutorial.Constants.LEDGER_NAME;
+import static software.amazon.qldb.tutorial.Constants.STREAM_NAME;
+
+/**
+ * Demonstrates the QLDB stream functionality.
+ * <p>
+ * In this tutorial, we will create a Ledger and a stream for that Ledger. We
+ * will then start a stream reader and wait for few documents to be inserted
+ * that will be pulled from the Kinesis stream into the {@link #recordBuffer}
+ * and the logs and for this tutorial code using the Amazon Kinesis Client
+ * library
+ *
+ * @see <a href="https://github.com/awslabs/amazon-kinesis-client">Amazon Kinesis Client library</a>
+ */
+public final class StreamJournal {
+
+    /**
+     * AWS service clients used throughout the tutorial code.
+     */
+    public static AmazonKinesis kinesis = AmazonKinesisClientBuilder.defaultClient();
+    public static AmazonIdentityManagement iam = AmazonIdentityManagementClientBuilder.defaultClient();
+    public static AmazonQLDB qldb = AmazonQLDBClientBuilder.defaultClient();
+    public static AWSCredentialsProvider credentialsProvider = DefaultAWSCredentialsProviderChain.getInstance();
+    /**
+     * Shared variables to make the tutorial code easy to follow.
+     */
+    public static String ledgerName = LEDGER_NAME;
+    public static String streamName = STREAM_NAME;
+    public static String streamId;
+    public static String kdsArn;
+    public static String roleArn;
+    public static String kdsName;
+    public static String kdsRoleName;
+    public static String kdsPolicyName;
+    public static Worker kdsReader;
+    public static String regionName = "us-east-1";
+    public static Date exclusiveEndTime;
+    public static boolean isAggregationEnabled;
+    public static KinesisClientLibConfiguration kclConfig;
+    public static int bufferCapacity;
+    public static CompletableFuture<Void> waiter;
+    public static List<StreamRecord> recordBuffer = new ArrayList<>();
+    public static Function<StreamRecord, Boolean> areAllRecordsFound;
+    public static String STREAM_ROLE_KINESIS_STATEMENT_TEMPLATE =
+            "{" +
+                    "   \"Sid\": \"QLDBStreamKinesisPermissions\"," +
+                    "   \"Action\": [\"kinesis:PutRecord\", \"kinesis:PutRecords\", " +
+                    "\"kinesis:DescribeStream\", \"kinesis:ListShards\"]," +
+                    "   \"Effect\": \"Allow\"," +
+                    "   \"Resource\": \"{kdsArn}\"" +
+                    "}";
+
+    public static final String POLICY_TEMPLATE =
+            "{" +
+                    "   \"Version\" : \"2012-10-17\"," +
+                    "   \"Statement\": [ {statements} ]" +
+                    "}";
+
+    public static String ASSUME_ROLE_POLICY = POLICY_TEMPLATE.replace(
+            "{statements}",
+            "{" +
+                    "   \"Effect\": \"Allow\"," +
+                    "   \"Principal\": {" +
+                    "       \"Service\": [\"qldb.amazonaws.com\"]" +
+                    "   }," +
+                    "   \"Action\": [ \"sts:AssumeRole\" ]" +
+                    "}");
+
+    private static ObjectReader reader = Constants.MAPPER.readerFor(StreamRecord.class);
+    private static final Logger log = LoggerFactory.getLogger(StreamJournal.class);
+    private static final int MAX_RETRIES = 60;
+
+    private StreamJournal() { }
+
+    /**
+     * Runs the tutorial.
+     *
+     * @param args not required.
+     */
+    public static void main(final String... args) {
+
+        initialize();
+
+        try {
+            runStreamJournalTutorial();
+            log.info("You can use the AWS CLI or Console to browse the resources that were created.");
+        } catch (Exception ex) {
+            log.error("Something went wrong.", ex);
+        } finally {
+            log.info("Press Enter to clean up and exit.");
+            try {
+                System.in.read();
+            } catch (Exception ignore) {
+            }
+            log.info("Starting cleanup...");
+            cleanupQldbResources();
+            cleanupKinesisResources();
+            System.exit(0);
+        }
+    }
+
+    /**
+     * We will stream 24 records to Kinesis:
+     * 1) Control record with CREATED status
+     * 2) 2 Summary records
+     * 3) 20 Revision records
+     * 4) Control record with COMPLETED status (if the stream is bounded)
+     *
+     * @param isBounded true if the stream has an exclusive end time.
+     * @return the number of expected records.
+     */
+    public static int numberOfExpectedRecords(boolean isBounded) {
+        int baseNumber = SampleData.LICENSES.size() +
+                SampleData.PEOPLE.size() +
+                SampleData.REGISTRATIONS.size() +
+                SampleData.VEHICLES.size() +
+                // records of Block Summary
+                2 +
+                // CREATED Control Record
+                1;
+
+        // Bounded Stream will contain also COMPLETED Control Record
+        return isBounded ? (baseNumber + 1) : baseNumber;
+    }
+
+    /**
+     * Initialize the tutorial code.
+     */
+    public static void initialize() {
+        kdsName = ledgerName + "-kinesis-stream";
+        kdsRoleName = ledgerName + "-stream-role";
+        kdsPolicyName = ledgerName + "-stream-policy";
+        kclConfig = new KinesisClientLibConfiguration(
+                ledgerName,
+                kdsName,
+                credentialsProvider,
+                "tutorial")
+                .withInitialPositionInStream(TRIM_HORIZON)
+                .withRegionName(regionName);
+        isAggregationEnabled = true;
+        bufferCapacity = numberOfExpectedRecords(exclusiveEndTime != null);
+        areAllRecordsFound = record -> recordBuffer.size() == bufferCapacity;
+        waiter = new CompletableFuture<>();
+    }
+
+    /**
+     * Runs the tutorial code.
+     *
+     * @throws Exception is thrown when something goes wrong in the tutorial.
+     */
+    public static void runStreamJournalTutorial() throws Exception {
+        createLedger();
+        createTables();
+        insertDocuments();
+        createQldbStream();
+        startStreamReader();
+        waiter.get();
+
+        if (exclusiveEndTime != null) {
+            waitForQldbStreamCompletion();
+        }
+        log.info("Buffered {} records so far.", recordBuffer.size());
+        validateStreamRecordsHashChain();
+    }
+
+    /**
+     * Creates a ledger.
+     *
+     * @throws Exception if the ledger creation fails.
+     */
+    public static void createLedger() throws Exception {
+        CreateLedger.create(ledgerName);
+        CreateLedger.waitForActive(ledgerName);
+    }
+
+    /**
+     * Creates a few tables in the ledger created using {@link #createLedger()}.
+     */
+    public static void createTables() {
+        CreateTable.main();
+
+        try {
+            sleep(4000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void insertDocuments() {
+        InsertDocument.main();
+    }
+
+    /**
+     * Create a QLDB Stream.
+     *
+     * @return the QLDB Stream description.
+     * @throws InterruptedException if the thread is interrupted while waiting
+     * for stream creation.
+     */
+    public static JournalKinesisStreamDescription createQldbStream() throws InterruptedException {
+        log.info("Creating Kinesis data stream with name: '{}'...", kdsName);
+        createKdsIfNotExists();
+        log.info("Creating QLDB stream...");
+        StreamJournalToKinesisRequest request = new StreamJournalToKinesisRequest()
+                .withKinesisConfiguration(getKdsConfig())
+                .withInclusiveStartTime(Date.from(Instant.now().minus(Duration.ofDays(1))))
+                .withRoleArn(getOrCreateKdsRole())
+                .withLedgerName(ledgerName)
+                .withStreamName(streamName);
+
+        if (exclusiveEndTime != null) {
+            request = request.withExclusiveEndTime(exclusiveEndTime);
+        }
+        StreamJournalToKinesisResult result = qldb.streamJournalToKinesis(request);
+        streamId = result.getStreamId();
+        DescribeJournalKinesisStreamResult describeResult = describeQldbStream();
+        log.info("Created QLDB stream: {} Current status: {}.",
+                streamId,
+                describeResult.getStream().getStatus());
+        return describeResult.getStream();
+    }
+
+    /**
+     * Create a Kinesis Data Stream to stream Journal data to Kinesis.
+     */
+    public static void createKdsIfNotExists() {
+        try {
+            log.info("Check if Kinesis Data Stream already exists.");
+            DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest()
+                    .withStreamName(kdsName);
+            DescribeStreamResult describeStreamResponse = kinesis.describeStream(describeStreamRequest);
+            log.info("Describe stream response: " + describeStreamResponse);
+            kdsArn = describeStreamResponse.getStreamDescription().getStreamARN();
+            String streamStatus = describeStreamResponse.getStreamDescription().getStreamStatus();
+            if (streamStatus.equals("ACTIVE")) {
+                log.info("Kinesis Data Stream is already Active.");
+                return;
+            }
+        } catch (ResourceNotFoundException e) {
+            kinesis.createStream(kdsName, 1);
+        }
+        waitForKdsActivation();
+    }
+
+    /**
+     * Wait for Kinesis Data Stream completion.
+     */
+    public static void waitForQldbStreamCompletion() {
+        DescribeJournalKinesisStreamRequest describeStreamRequest = new DescribeJournalKinesisStreamRequest()
+                .withStreamId(streamId)
+                .withLedgerName(ledgerName);
+
+        int retries = 0;
+        while (retries < MAX_RETRIES) {
+            DescribeJournalKinesisStreamResult describeStreamResponse = qldb.describeJournalKinesisStream(describeStreamRequest);
+            String streamStatus = describeStreamResponse.getStream().getStatus();
+            log.info("Waiting for Stream Completion. Current streamStatus: {}.", streamStatus);
+            if (streamStatus.equals("COMPLETED")) {
+                break;
+            }
+            try {
+                sleep(1000);
+            } catch (Exception ignore) {
+            }
+            retries++;
+        }
+        if (retries >= MAX_RETRIES) {
+            throw new RuntimeException("Kinesis Stream with name " + kdsName + " never went completed.");
+        }
+    }
+
+    /**
+     * Wait for Kinesis Data Stream activation.
+     */
+    private static void waitForKdsActivation() {
+        log.info("Waiting for Kinesis Stream to become Active.");
+        DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest()
+                .withStreamName(kdsName);
+
+        int retries = 0;
+        while (retries < MAX_RETRIES) {
+            try {
+                log.info("Sleeping for 5 sec before polling Kinesis Stream status.");
+                sleep(5 * 1000);
+            } catch (Exception ignore) {
+            }
+
+            DescribeStreamResult describeStreamResponse = kinesis.describeStream(describeStreamRequest);
+            kdsArn = describeStreamResponse.getStreamDescription().getStreamARN();
+            String streamStatus = describeStreamResponse.getStreamDescription().getStreamStatus();
+            if (streamStatus.equals("ACTIVE")) {
+                break;
+            }
+            log.info("Still waiting for Kinesis Stream to become Active. Current streamStatus: {}.", streamStatus);
+            try {
+                sleep(1000);
+            } catch (Exception ignore) {
+            }
+            retries++;
+        }
+        if (retries >= MAX_RETRIES) {
+            throw new RuntimeException("Kinesis Stream with name " + kdsName + " never went active");
+        }
+    }
+
+    /**
+     * Create role and attaches policy to allow put records in KDS.
+     *
+     * @return roleArn for Kinesis Data Streams.
+     * @throws InterruptedException if the thread is interrupted while creating
+     * the KDS role.
+     */
+    public static String getOrCreateKdsRole() throws InterruptedException {
+        try {
+            roleArn = iam.getRole(new GetRoleRequest().withRoleName(kdsRoleName)).getRole().getArn();
+            try {
+                iam.getRolePolicy(new GetRolePolicyRequest().withPolicyName(kdsPolicyName).withRoleName(kdsRoleName));
+            } catch (NoSuchEntityException e) {
+                attachPolicyToKdsRole();
+                sleep(20 * 1000);
+            }
+        } catch (NoSuchEntityException e) {
+            log.info("The provided role doesn't exist. Creating the role with name: {}. Please wait...", kdsRoleName);
+            CreateRoleRequest createRole = new CreateRoleRequest()
+                    .withRoleName(kdsRoleName)
+                    .withAssumeRolePolicyDocument(ASSUME_ROLE_POLICY);
+            roleArn = iam.createRole(createRole).getRole().getArn();
+            attachPolicyToKdsRole();
+            sleep(20 * 1000);
+        }
+        return roleArn;
+    }
+
+    private static void attachPolicyToKdsRole() {
+        String rolePolicy = POLICY_TEMPLATE
+                .replace("{statements}", STREAM_ROLE_KINESIS_STATEMENT_TEMPLATE)
+                .replace("{kdsArn}", kdsArn);
+        PutRolePolicyRequest putPolicy = new PutRolePolicyRequest()
+                .withRoleName(kdsRoleName)
+                .withPolicyName(kdsPolicyName)
+                .withPolicyDocument(rolePolicy);
+        iam.putRolePolicy(putPolicy);
+    }
+
+    /**
+     * Generate the {@link KinesisConfiguration} for the QLDB stream.
+     *
+     * @return {@link KinesisConfiguration} for the QLDB stream.
+     */
+    public static KinesisConfiguration getKdsConfig() {
+        KinesisConfiguration kinesisConfiguration = new KinesisConfiguration().withStreamArn(kdsArn);
+
+        // By default, aggregationEnabled is true so it can be specified only if needed.
+        if (!isAggregationEnabled) {
+            kinesisConfiguration = kinesisConfiguration.withAggregationEnabled(isAggregationEnabled);
+        }
+        return kinesisConfiguration;
+    }
+
+    /**
+     * List QLDB streams for the ledger.
+     *
+     * @return map of stream Id to description for the ledger's QLDB streams.
+     */
+    public static Map<String, JournalKinesisStreamDescription> listQldbStreamsForLedger() {
+        Map<String, JournalKinesisStreamDescription> streams = new HashMap<>();
+        String nextToken = null;
+        do {
+            ListJournalKinesisStreamsForLedgerRequest listRequest = new ListJournalKinesisStreamsForLedgerRequest()
+                    .withLedgerName(ledgerName)
+                    .withNextToken(nextToken);
+            ListJournalKinesisStreamsForLedgerResult listResult = qldb.listJournalKinesisStreamsForLedger(listRequest);
+            listResult.getStreams().forEach(streamDescription -> streams.put(streamDescription.getStreamId(), streamDescription));
+            nextToken = listResult.getNextToken();
+        } while (nextToken != null);
+        return streams;
+    }
+
+
+    /**
+     * Describe the QLDB stream.
+     *
+     * @return description of the QLDB stream.
+     */
+    private static DescribeJournalKinesisStreamResult describeQldbStream() {
+        DescribeJournalKinesisStreamRequest describeStreamRequest = new DescribeJournalKinesisStreamRequest()
+                .withStreamId(streamId)
+                .withLedgerName(ledgerName);
+
+        return qldb.describeJournalKinesisStream(describeStreamRequest);
+    }
+
+    /**
+     * Starts the stream reader using Kinesis client library.
+     */
+    public static void startStreamReader() {
+        log.info("Starting stream reader...");
+
+        kdsReader = new Worker.Builder()
+                .recordProcessorFactory(new RevisionProcessorFactory())
+                .config(kclConfig)
+                .build();
+
+        Executors.newSingleThreadExecutor().submit(() -> kdsReader.run());
+    }
+
+    /**
+     * Clean up QLDB resources used by the tutorial code.
+     */
+    public static void cleanupQldbResources() {
+        stopStreamReader();
+        if (exclusiveEndTime == null) {
+            cancelQldbStream();
+        }
+        deleteLedger();
+    }
+
+    /**
+     * Cancel the QLDB stream.
+     */
+    public static void cancelQldbStream() {
+        if (null == streamId) {
+            return;
+        }
+        try {
+            CancelJournalKinesisStreamRequest request = new CancelJournalKinesisStreamRequest()
+                    .withLedgerName(ledgerName)
+                    .withStreamId(streamId);
+            qldb.cancelJournalKinesisStream(request);
+            log.info("QLDB stream was cancelled.");
+        } catch (com.amazonaws.services.qldb.model.ResourceNotFoundException ex) {
+            log.info("No QLDB stream to cancel.");
+        } catch (Exception ex) {
+            log.warn("Error cancelling QLDB stream.", ex);
+        }
+    }
+
+    /**
+     * Stops the Stream Reader.
+     */
+    public static void stopStreamReader() {
+        if (null == kdsReader) {
+            return;
+        }
+        try {
+            kdsReader.startGracefulShutdown().get(30, TimeUnit.SECONDS);
+            log.info("Stream reader was stopped.");
+        } catch (Exception ex) {
+            log.warn("Error stopping Stream reader.", ex);
+        }
+    }
+
+    public static void validateStreamRecordsHashChain() {
+        List<JournalBlock> journalBlocks = streamRecordsToJournalBlocks();
+        ValidateQldbHashChain.verify(journalBlocks);
+    }
+
+    private static List<JournalBlock> streamRecordsToJournalBlocks() {
+        Map<ByteBuffer, QldbRevision> revisionsByHash = new HashMap<>();
+        recordBuffer.stream()
+                .filter(record -> record.getRecordType().equals("REVISION_DETAILS"))
+                .forEach(record -> {
+                    try {
+                        Revision revision = ((RevisionDetailsRecord) record.getPayload()).getRevision();
+                        byte[] revisionHash = revision.getHash();
+                        revisionsByHash.put(
+                                wrap(revisionHash).asReadOnlyBuffer(),
+                                QldbRevision.fromIon((IonStruct) Constants.MAPPER.writeValueAsIonValue(revision)));
+                    } catch (IOException e) {
+                        throw new IllegalArgumentException("Could not map RevisionDetailsRecord to QldbRevision.", e);
+                    }
+                });
+        return recordBuffer.stream()
+                .filter(streamRecord -> streamRecord.getRecordType().equals("BLOCK_SUMMARY"))
+                .map(streamRecord -> (BlockSummaryRecord) streamRecord.getPayload())
+                .distinct()
+                .map(blockSummaryRecord -> blockSummaryRecordToJournalBlock(blockSummaryRecord, revisionsByHash))
+                .sorted(Comparator.comparingLong(o -> o.getBlockAddress().getSequenceNo()))
+                .collect(Collectors.toList());
+    }
+
+    private static JournalBlock blockSummaryRecordToJournalBlock(BlockSummaryRecord blockSummaryRecord,
+                                                                 Map<ByteBuffer, QldbRevision> revisionsByHash) {
+        List<QldbRevision> revisions = null;
+        if (blockSummaryRecord.getRevisionSummaries() != null) {
+            revisions = blockSummaryRecord.getRevisionSummaries().stream().map(revisionSummary -> {
+                if (revisionSummary.getDocumentId() != null) {
+                    return revisionsByHash.get(wrap(revisionSummary.getHash()).asReadOnlyBuffer());
+                } else {
+                    return new QldbRevision(null, null, revisionSummary.getHash(), null);
+                }
+            }).collect(Collectors.toList());
+        }
+        return new JournalBlock(
+                blockSummaryRecord.getBlockAddress(),
+                blockSummaryRecord.getTransactionId(),
+                blockSummaryRecord.getBlockTimestamp(),
+                blockSummaryRecord.getBlockHash(),
+                blockSummaryRecord.getEntriesHash(),
+                blockSummaryRecord.getPreviousBlockHash(),
+                blockSummaryRecord.getEntriesHashList(),
+                blockSummaryRecord.getTransactionInfo(),
+                revisions);
+    }
+
+    /**
+     * Deletes the ledger
+     */
+    private static void deleteLedger() {
+        try {
+            DeletionProtection.setDeletionProtection(ledgerName, false);
+            DeleteLedger.delete(ledgerName);
+            DeleteLedger.waitForDeleted(ledgerName);
+            log.info("Ledger was deleted.");
+        } catch (com.amazonaws.services.qldb.model.ResourceNotFoundException ex) {
+            log.info("No Ledger to delete.");
+        } catch (Exception ex) {
+            log.warn("Error deleting Ledger.", ex);
+        }
+    }
+
+    /**
+     * Deletes the KDS.
+     */
+    public static void cleanupKinesisResources() {
+        try {
+            kinesis.deleteStream(kdsName);
+            waitForKdsDeletion();
+            log.info("KDS was deleted.");
+        } catch (ResourceNotFoundException ex) {
+            log.info("No KDS to delete.");
+        } catch (Exception ex) {
+            log.warn("Error deleting KDS.", ex);
+        }
+    }
+
+    /**
+     * Waits for KDS to be deleted.
+     */
+    private static void waitForKdsDeletion() {
+        DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest();
+        describeStreamRequest.setStreamName(kdsName);
+
+        int retries = 0;
+        while (retries < MAX_RETRIES) {
+
+            try {
+                kinesis.describeStream(describeStreamRequest);
+            } catch (ResourceNotFoundException ex) {
+                break;
+            }
+
+            try {
+                sleep(1000);
+            } catch (Exception ignore) {
+            }
+            retries++;
+        }
+        if (retries >= MAX_RETRIES) {
+            throw new RuntimeException("Kinesis Stream with name " + kdsName + " could not be deleted.");
+        }
+    }
+
+    /**
+     * Factory for {@link IRecordProcessor}s that process records from KDS.
+     */
+    private static class RevisionProcessorFactory implements IRecordProcessorFactory {
+        @Override
+        public IRecordProcessor createProcessor() {
+            return new RevisionProcessor();
+        }
+    }
+
+    /**
+     * Processes records that show up on the KDS.
+     */
+    private static class RevisionProcessor implements IRecordProcessor {
+
+        private static final Logger log = LoggerFactory.getLogger(RevisionProcessor.class);
+
+        @Override
+        public void initialize(String shardId) {
+            log.info("Starting RevisionProcessor.");
+        }
+
+        @Override
+        public void processRecords(List<Record> records, IRecordProcessorCheckpointer iRecordProcessorCheckpointer) {
+            log.info("Processing {} record(s)", records.size());
+            records.forEach(r -> {
+                try {
+                    log.info("------------------------------------------------");
+                    log.info("Processing Record with Seq: {}, PartitionKey: {}, IonText: {}",
+                            r.getSequenceNumber(), r.getPartitionKey(), toIonText(r.getData()));
+                    StreamRecord record = reader.readValue(r.getData().array());
+                    log.info("Record Type: {}, Payload: {}.", record.getRecordType(), record.getPayload());
+                    if (record.getQldbStreamArn().contains(streamId)) {
+                        recordBuffer.add(record);
+                        if (areAllRecordsFound.apply(record)) {
+                            waiter.complete(null);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Error processing record. ", e);
+                }
+            });
+        }
+
+        void rewrite(byte[] data, IonWriter writer) throws IOException {
+            IonReader reader = IonReaderBuilder.standard().build(data);
+            writer.writeValues(reader);
+        }
+
+        private String toIonText(ByteBuffer data) throws IOException {
+            StringBuilder stringBuilder = new StringBuilder();
+            try (IonWriter prettyWriter = IonTextWriterBuilder.minimal().build(stringBuilder)) {
+                rewrite(data.array(), prettyWriter);
+            }
+            return stringBuilder.toString();
+        }
+
+        @Override
+        public void shutdown(IRecordProcessorCheckpointer iRecordProcessorCheckpointer, ShutdownReason shutdownReason) {
+            log.info("Shutting down RevisionProcessor.");
+        }
+    }
+}


### PR DESCRIPTION
The sample provides guidance
on how to use Amazon QLDB Streams.
The sample educates on how to create
QLDB streams, consume records from the
stream and delete streams. The sample
also demonstrates how to use the stream
data to validate the hash chain of a ledger.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
