### PR TITLE
Fix AWS QLDB SDK version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'application'
 mainClassName = "software.amazon.qldb.tutorial." + System.getProperty("tutorial")
 
 group 'software.amazon.qldb'
-version '1.1.0'
+version '1.2.0'
 
 sourceCompatibility = 1.8
 
@@ -17,7 +17,6 @@ compileJava {
 }
 
 dependencies {
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-qldb', version: '1.11.649'
     compile group: 'software.amazon.qldb', name: 'amazon-qldb-driver-java', version: '1.1.0'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.649'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-iam', version: '1.11.649'


### PR DESCRIPTION
Fix AWS QLDB SDK version

This changes updates the version of QLDB that includes the model to use the Streaming feature of QLDB. See: https://github.com/aws-samples/amazon-qldb-dmv-sample-java/tree/master/src/main/java/software/amazon/qldb/tutorial/streams

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
