### PR TITLE
Upgrade Amazon QLDB driver to v2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'application'
 mainClassName = "software.amazon.qldb.tutorial." + System.getProperty("tutorial")
 
 group 'software.amazon.qldb'
-version '2.0.0-rc.1'
+version '2.0.0'
 
 sourceCompatibility = 1.8
 
@@ -18,7 +18,7 @@ compileJava {
 }
 
 dependencies {
-    compile group: 'software.amazon.qldb', name: 'amazon-qldb-driver-java', version: '2.0.0-rc.1'
+    compile group: 'software.amazon.qldb', name: 'amazon-qldb-driver-java', version: '2.0.0'
     
     compile group: 'com.amazonaws', name: 'aws-java-sdk-core', version: '1.11.649'
     compile group: 'com.amazonaws', name: 'aws-java-sdk-iam', version: '1.11.649'


### PR DESCRIPTION
Upgrade Amazon QLDB driver to v2.0.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
