### PR TITLE
Wait for tables to create successfully in StreamJournal tutorial

### DIFF
--- a/src/main/java/software/amazon/qldb/tutorial/streams/StreamJournal.java
+++ b/src/main/java/software/amazon/qldb/tutorial/streams/StreamJournal.java
@@ -270,7 +270,11 @@ public final class StreamJournal {
      */
     public static void createTables() {
         CreateTable.main();
-    }
+        try {
+            Thread.sleep(4000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }}
 
     public static void insertDocuments() {
         InsertDocument.main();

--- a/src/main/java/software/amazon/qldb/tutorial/streams/StreamJournal.java
+++ b/src/main/java/software/amazon/qldb/tutorial/streams/StreamJournal.java
@@ -274,7 +274,8 @@ public final class StreamJournal {
             Thread.sleep(4000);
         } catch (InterruptedException e) {
             e.printStackTrace();
-        }}
+        }
+    }
 
     public static void insertDocuments() {
         InsertDocument.main();


### PR DESCRIPTION
Amazon QLDB takes short time before the table is ready to be used. Any query made on that table before the table creation completes can fail. For the purpose of this sample application, I have added a small sleep after issuing the `CREATE TABLE` query in the StreamJournal tutorial.

In v1.x of this sample, we had the `sleep` in place already, but it was accidentally removed in v2.x.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
