### PR TITLE
Bump log4j-slf4j-impl version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,5 +31,5 @@ dependencies {
 
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-ion', version: '2.13.0'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.14.1'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.15.0'
 }


### PR DESCRIPTION
Mitigates [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) in case anyone uses this project as a starter template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
