### PR TITLE
Fix journal block hash verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 .settings/
 bin/
 .git
-
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     compile group: 'com.amazonaws', name: 'aws-java-sdk-qldb', version: '1.12.134'
     compile group: 'com.amazonaws', name: 'amazon-kinesis-client', version: '1.14.7'
 
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-ion', version: '2.13.1'
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.13.1'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-ion', version: '2.12.6'
     compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.1'
 }

--- a/src/main/java/software/amazon/qldb/tutorial/qldb/JournalBlock.java
+++ b/src/main/java/software/amazon/qldb/tutorial/qldb/JournalBlock.java
@@ -160,8 +160,14 @@ public final class JournalBlock {
         if (!Arrays.deepEquals(getEntriesHashList(), that.getEntriesHashList())) {
             return false;
         }
-        if (!getTransactionInfo().equals(that.getTransactionInfo())) {
-            return false;
+        if (getTransactionInfo() != null) {
+            if (!getTransactionInfo().equals(that.getTransactionInfo())) {
+                return false;
+            }
+        } else {
+            if (that.getTransactionInfo() != null) {
+                return false;
+            }
         }
         return getRevisions() != null ? getRevisions().equals(that.getRevisions()) : that.getRevisions() == null;
     }
@@ -175,7 +181,7 @@ public final class JournalBlock {
         result = 31 * result + Arrays.hashCode(getEntriesHash());
         result = 31 * result + Arrays.hashCode(getPreviousBlockHash());
         result = 31 * result + Arrays.deepHashCode(getEntriesHashList());
-        result = 31 * result + getTransactionInfo().hashCode();
+        result = 31 * result + (getTransactionInfo() != null ? getTransactionInfo().hashCode() : 0);
         result = 31 * result + (getRevisions() != null ? getRevisions().hashCode() : 0);
         return result;
     }
@@ -217,10 +223,12 @@ public final class JournalBlock {
         Set<ByteBuffer> entriesHashSet = new HashSet<>();
         Arrays.stream(entriesHashList).forEach(hash -> entriesHashSet.add(wrap(hash).asReadOnlyBuffer()));
 
-        byte[] computedTransactionInfoHash = computeTransactionInfoHash();
-        if (!entriesHashSet.contains(wrap(computedTransactionInfoHash).asReadOnlyBuffer())) {
-            throw new IllegalArgumentException(
-                    "Block transactionInfo hash is not contained in the QLDB block entries hash list.");
+        if (transactionInfo != null) {
+            byte[] computedTransactionInfoHash = computeTransactionInfoHash();
+            if (!entriesHashSet.contains(wrap(computedTransactionInfoHash).asReadOnlyBuffer())) {
+                throw new IllegalArgumentException(
+                        "Block transactionInfo hash is not contained in the QLDB block entries hash list.");
+            }
         }
 
         if (revisions != null) {

--- a/src/main/java/software/amazon/qldb/tutorial/qldb/QldbRevision.java
+++ b/src/main/java/software/amazon/qldb/tutorial/qldb/QldbRevision.java
@@ -182,9 +182,8 @@ public final class QldbRevision {
     public void verifyRevisionHash() {
         // Certain internal-only system revisions only contain a hash which cannot be
         // further computed. However, these system hashes still participate to validate
-        // the journal block. User revisions will always contain values for all fields
-        // and can therefore have their hash computed.
-        if (blockAddress == null && metadata == null && data == null) {
+        // the journal block.
+        if (blockAddress == null || metadata == null || data == null) {
             return;
         }
 


### PR DESCRIPTION
*Issue #, if available:*
#215 

*Description of changes:*
The `transactionInfo` field of the journal block is an optional field and
should not be used for block hash verification when it is not present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
